### PR TITLE
Update Dockerfile to fix image building error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM bamos/ubuntu-opencv-dlib-torch:ubuntu_14.04-opencv_2.4.11-dlib_18.16-torch_
 MAINTAINER Hervé Bredin <bredin@limsi.fr>
 
 # python package management
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -yq --no-install-recommends \
     python \
     python-dev \
-    python-pip
+    python-pip=1.5.4-1
 
 # scientific python
 RUN pip install numpy
@@ -14,7 +14,7 @@ RUN pip install jupyter
 RUN pip install matplotlib
 
 # pyannote.core notebook support
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -yq --no-install-recommends \
     graphviz \
     libgraphviz-dev
 RUN pip install pyannote.core[notebook]


### PR DESCRIPTION
because the software source list is broken, we cann't build the docker image successfully.
By specifying the python-pip as 1.5.4-1 version, we can install python-pip and build the image successfully.
The building error message is:

> Err http://archive.ubuntu.com/ubuntu/ trusty-updates/universe python-pip-whl all 1.5.4-1ubuntu3
>   404  Not Found [IP: 91.189.88.162 80]
> Get:15 http://archive.ubuntu.com/ubuntu/ trusty-updates/main python-urllib3 all 1.7.1-1ubuntu4 [39.5 kB]
> Get:16 http://archive.ubuntu.com/ubuntu/ trusty-updates/main python-requests all 2.2.1-1ubuntu0.3 [43.1 kB]
> Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main python-setuptools all 3.3-1ubuntu2 [230 kB]
> Err http://archive.ubuntu.com/ubuntu/ trusty-updates/universe python-pip all 1.5.4-1ubuntu3
>   404  Not Found [IP: 91.189.88.162 80]
> Fetched 1658 kB in 15s (104 kB/s)
> E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/p/python-pip/python-pip-whl_1.5.4-1ubuntu3_all.deb  404  Not Found [IP: 91.189.88.162 80]
> E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/p/python-pip/python-pip_1.5.4-1ubuntu3_all.deb  404  Not Found [IP: 91.189.88.162 80]
> E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
> The command '/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends     python     python-dev     python-pip' returned a non-zero code: 100
