### PR TITLE
pyannote-face.py demo exception caused by numpy 0.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'tqdm >= 2.0.0',
         'dlib == 19.4.0',
         'munkres >= 1.0.7',
-        'moviepy == 0.2.2.11'
+        'moviepy >= 0.2.2.13'
     ],
 
     version=versioneer.get_version(),


### PR DESCRIPTION
when running the pyannote-video nootbook, this error will occur:

```
Traceback (most recent call last):
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/bin/pyannote-face.py", line 483, in <module>
    shift=shift, labels=labels)
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/bin/pyannote-face.py", line 409, in demo
    audio_clip = AudioFileClip(filename)
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/lib/python3.5/site-packages/moviepy/audio/io/AudioFileClip.py", line 63, in __init__
    buffersize=buffersize)
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/lib/python3.5/site-packages/moviepy/audio/io/readers.py", line 70, in __init__
    self.buffer_around(1)
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/lib/python3.5/site-packages/moviepy/audio/io/readers.py", line 234, in buffer_around
    self.buffer =  self.read_chunk(self.buffersize)
  File "/home/ruohan.chen/.anaconda3/envs/pyannote/lib/python3.5/site-packages/moviepy/audio/io/readers.py", line 123, in read_chunk
    self.nchannels))
TypeError: 'float' object cannot be interpreted as an integer
```

This problem has been solved in moviepy 0.2.2.13 version, so it should great equal than 0.2.2.13. This Fix is described at Zulko/moviepy#383